### PR TITLE
Fix JSON folding toggler width

### DIFF
--- a/formiko/data/__init__.py
+++ b/formiko/data/__init__.py
@@ -1,0 +1,1 @@
+"""Resource package for Formiko."""

--- a/formiko/data/jsonfold.css
+++ b/formiko/data/jsonfold.css
@@ -1,8 +1,13 @@
 body{font-family:monospace}
 .jblock{margin-left:1em}
-.jblock>.jtoggler{cursor:pointer;margin-right:0.2em}
+.jblock>.jtoggler{
+  cursor:pointer;
+  margin-right:0.2em;
+  display:inline-block;
+  width:1em;
+}
 .jblock.collapsed>.children{display:none}
-.jtoggler::before{content:"\25bc";display:inline-block;width:1em}
+.jtoggler::before{content:"\25bc";display:block}
 .jblock.collapsed>.jtoggler::before{content:"\25b6"}
 .jkey{color:#922}
 .jstr{color:#070}


### PR DESCRIPTION
## Summary
- keep jsonfold resources as a package
- widen `.jtoggler` so click area exists
- add package docstring to silence ruff

## Testing
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_688a452305e8832190a060697f74edbe