### PR TITLE
Fix click propagation in renderer

### DIFF
--- a/formiko/renderer.py
+++ b/formiko/renderer.py
@@ -313,18 +313,15 @@ class Renderer(Overlay):
         return True  # disable context menu for now
 
     def on_button_release(self, webview, event):
-        """Catch release-button only when try to follow link.
-
-        Context menu is catch by webview before this callback.
-        """
-        if event.button == self.context_button:
-            return True
-        if self.link_uri:
-            if self.link_uri.startswith("file://"):  # try to open source
+        """Open links and let other clicks propagate."""
+        if event.button != self.context_button and self.link_uri:
+            if self.link_uri.startswith("file://"):
                 self.find_and_opendocument(self.link_uri[7:].split("#")[0])
             else:
                 show_uri_on_window(None, self.link_uri, 0)
-        return True
+            return True
+
+        return False
 
     def find_and_opendocument(self, file_path):
         """Find file on disk and open it."""


### PR DESCRIPTION
## Summary
- open links on button release but let other clicks through

## Testing
- `ruff check formiko/renderer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aeadb82f483219b65d2cad0e3f80e