### PR TITLE
Initialize renderer window before parser

### DIFF
--- a/formiko/renderer.py
+++ b/formiko/renderer.py
@@ -502,12 +502,15 @@ class Renderer(Overlay):
         self.link_uri = None
         self.context_button = 3  # will be rewrite by real value
 
-        self.set_writer(writer)
-        self.set_parser(parser)
-        self.style = style
-        self.tab_width = 8
+        # Window reference must be available before parser initialization
         self.__win = win
         self.parser_instance = None
+
+        self.set_writer(writer)
+        self.set_parser(parser)
+
+        self.style = style
+        self.tab_width = 8
 
 
     def on_theme_changed(self, obj=None, pspec=None):


### PR DESCRIPTION
## Summary
- Ensure renderer window attribute is set before parser initialization to prevent attribute errors
- Avoid resetting the parser instance during renderer construction

## Testing
- `ruff check .` *(fails: import formatting and docstring issues)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'jsonpath_ng')*

------
https://chatgpt.com/codex/tasks/task_e_688d7832d3a88321a479da782557f15f