### PR TITLE
feat: fold jsonpath search results

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,69 +1,84 @@
-import pytest
+"""Tests for JSONPath filter behavior."""
+
 from jsonpath_ng.ext import parse
 
 from formiko.renderer import JsonPreview
 
 
 def filter_json_for_test(data, expression):
-    """
-    A test helper function to simulate the filtering process
-    and return the pruned data and highlight paths.
-    """
+    """Return filtered results for tests."""
     preview = JsonPreview()
-    preview._json_data = data
+    preview._json_data = data  # noqa: SLF001
 
     if not expression.strip():
-        return data, []
+        return data, [], {""}
 
     expr = parse(expression)
     matches = expr.find(data)
 
-    if not matches:
-        return {}, []
+    highlights = []
+    expands = {""}
+    for m in matches:
+        current = m
+        while current:
+            p = str(current.full_path)
+            expands.add("" if p == "$" else p)
+            current = current.context
+        p = str(m.full_path)
+        highlights.append("" if p == "$" else p)
 
-    pruned_data = preview._build_pruned_tree(matches)
-    highlight_paths = [str(m.full_path) for m in matches]
-
-    return pruned_data, highlight_paths
+    return data, highlights, expands
 
 
 def test_basic_filter():
+    """Expand only matching branch for direct path."""
     data = {"a": {"b": 1}, "c": 2}
-    pruned, hl = filter_json_for_test(data, "$.a.b")
-    assert pruned == {"a": {"b": 1}}
+    pruned, hl, exp = filter_json_for_test(data, "$.a.b")
+    assert pruned == data
     assert hl == ["a.b"]
+    assert exp == {"", "a", "a.b"}
 
 
 def test_no_filter():
+    """Handle empty expression without folding."""
     data = {"a": {"b": 1}, "c": 2}
-    pruned, hl = filter_json_for_test(data, "")
+    pruned, hl, exp = filter_json_for_test(data, "")
     assert pruned == data
     assert hl == []
+    assert exp == {""}
 
 
 def test_no_matches():
+    """Collapse to root when no paths match."""
     data = {"a": {"b": 1}, "c": 2}
-    pruned, hl = filter_json_for_test(data, "$.d")
-    assert pruned == {}
+    pruned, hl, exp = filter_json_for_test(data, "$.d")
+    assert pruned == data
     assert hl == []
+    assert exp == {""}
 
 
 def test_wildcard_filter():
+    """Expand all children of wildcard path."""
     data = {"a": {"b": 1, "c": 2}}
-    pruned, hl = filter_json_for_test(data, "$.a.*")
-    assert pruned == {"a": {"b": 1, "c": 2}}
+    pruned, hl, exp = filter_json_for_test(data, "$.a.*")
+    assert pruned == data
     assert sorted(hl) == ["a.b", "a.c"]
+    assert exp == {"", "a", "a.b", "a.c"}
 
 
 def test_array_filter():
+    """Expand matching array index."""
     data = {"a": [10, 20, 30]}
-    pruned, hl = filter_json_for_test(data, "$.a[1]")
-    assert pruned == {"a": [20]}
+    pruned, hl, exp = filter_json_for_test(data, "$.a[1]")
+    assert pruned == data
     assert hl == ["a.[1]"]
+    assert exp == {"", "a", "a.[1]"}
 
 
 def test_root_is_match():
+    """Handle root match properly."""
     data = {"a": 1}
-    pruned, hl = filter_json_for_test(data, "$")
+    pruned, hl, exp = filter_json_for_test(data, "$")
     assert pruned == data
-    assert hl == ["$"]
+    assert hl == [""]
+    assert exp == {""}


### PR DESCRIPTION
## Summary
- expand matched JSONPath results and their parents while collapsing other branches
- highlight filtered JSON paths
- add tests for expanded path tracking

## Testing
- `ruff check formiko/renderer.py tests/test_filter.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonpath_ng')*


------
https://chatgpt.com/codex/tasks/task_e_688dcb8ef08c8321aa2ebaff941b9f2c