### PR TITLE
Unfold JSON nodes when filter cleared

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Version dev
   * Neovim support (formiko-vim)
     - new vte 2.91 dependency
   * JSON preview: add collapsible folding view (closes #XX)
+  * JSON preview: unfold all nodes when JSONPath filter is cleared
 
 
 Version 1.5.0


### PR DESCRIPTION
## Summary
- expand all JSON nodes when no JSONPath filter is active
- test coverage for empty-filter expansion
- document unfolding behavior in changelog

## Testing
- `ruff check formiko/renderer.py tests/test_filter.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonpath_ng')*


------
https://chatgpt.com/codex/tasks/task_e_688dcfeff1548321a38ca9dae92dfa30