### PR TITLE
Handle cleared JSONPath filters

### DIFF
--- a/formiko/renderer.py
+++ b/formiko/renderer.py
@@ -200,10 +200,13 @@ class JsonPreview:
             return f'<span class="jnull" data-jpath="{path}">null</span>'
         return f'<span class="jnum" data-jpath="{path}">{value}</span>'
 
-    def apply_path_filter(self, expression: str) -> None:  # noqa: C901
+    def apply_path_filter(self, expression: str | None) -> None:  # noqa: C901
         """Filter JSON by JSONPath and update the preview.
 
-        A callback is fired with (expression, match_count) when done.
+        A callback is fired with ``(expression, match_count)`` when done.
+
+        ``expression`` may be ``None`` or empty to clear any existing filter
+        and fully expand the JSON tree.
         """
         def _task():  # noqa: C901
             def collect_paths(val, path=""):
@@ -218,7 +221,7 @@ class JsonPreview:
                         paths |= collect_paths(v, new_path)
                 return paths
 
-            if not expression.strip():
+            if not expression or not expression.strip():
                 expands = collect_paths(self._json_data)
                 return self._json_data, [], expands, ""
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -10,7 +10,7 @@ def filter_json_for_test(data, expression):
     preview = JsonPreview()
     preview._json_data = data  # noqa: SLF001
 
-    if not expression.strip():
+    if not expression or not expression.strip():
         def collect_paths(val, path=""):
             paths = {path}
             if isinstance(val, dict):
@@ -55,6 +55,15 @@ def test_no_filter():
     """Handle empty expression without folding."""
     data = {"a": {"b": 1}, "c": 2}
     pruned, hl, exp = filter_json_for_test(data, "")
+    assert pruned == data
+    assert hl == []
+    assert exp == {"", "a", "a.b", "c"}
+
+
+def test_filter_cleared():
+    """Treat ``None`` expression as clearing the filter."""
+    data = {"a": {"b": 1}, "c": 2}
+    pruned, hl, exp = filter_json_for_test(data, None)
     assert pruned == data
     assert hl == []
     assert exp == {"", "a", "a.b", "c"}


### PR DESCRIPTION
## Summary
- treat missing or empty JSONPath expressions as a cleared filter
- cover filter clearing with additional unit tests

## Testing
- `ruff check formiko/renderer.py tests/test_filter.py`
- `pytest tests/test_filter.py -q` *(fails: ModuleNotFoundError: No module named 'jsonpath_ng')*


------
https://chatgpt.com/codex/tasks/task_e_688dd2b132ac8321918d8501f9b65d2c